### PR TITLE
Add header assertion for Invoke-PeridotArchetypeFinder

### DIFF
--- a/Peridot-Archetypes.md
+++ b/Peridot-Archetypes.md
@@ -220,9 +220,9 @@
 |Sunset|||||Sunset||Fleur|
 
 ### Example(s):
-![Neonimbus](./assets/Peridots/neonimbus-13.jpg)
-
 ![Medusa](./assets/Peridots/medusa-12.jpg)
+
+![Neonimbus](./assets/Peridots/neonimbus-13.jpg)
 
 ## Archetypes: Aurora, Sunset, Count: 2
 ### Compatibility Table:
@@ -869,9 +869,9 @@
 |Ram|||Ram||||Asparagus|
 
 ### Example(s):
-![Effervescent](./assets/Peridots/effervescent-5.jpg)
-
 ![Duranium](./assets/Peridots/duranium-4.jpg)
+
+![Effervescent](./assets/Peridots/effervescent-5.jpg)
 
 ## Archetypes: Peacock, Psychedelic, Count: 2
 ### Compatibility Table:

--- a/tests/Invoke-PeridotArchetypeFinder.Unit.Tests.ps1
+++ b/tests/Invoke-PeridotArchetypeFinder.Unit.Tests.ps1
@@ -10,5 +10,10 @@ InModuleScope $moduleName {
         It "Should not throw" {
             { Invoke-PeridotArchetypeFinder } | Should -Not -Throw
         }
+
+        It "Should output header" {
+            $result = Invoke-PeridotArchetypeFinder
+            $result | Should -Contain '# Peridot with Multi Archetype'
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend `Invoke-PeridotArchetypeFinder` tests to check for the output header

## Testing
- `Invoke-Pester -Path tests -Passthru`

------
https://chatgpt.com/codex/tasks/task_e_684bca1f53f88330ba6017e154ea484a